### PR TITLE
Show excerpt enabled content only on index page

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -12,11 +12,16 @@
     </h1>
   {% endif %}
 </header>
-<section>
-  {{ content | excerpt }}
-</section>
-<footer>
-  <div class="article-date">
-      {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %}
-  </div>
-</footer>
+{% if index %}
+  <section>{{ content | excerpt }}</section>
+  {% capture excerpted %}{{ content | has_excerpt }}{% endcapture %}
+  {% if excerpted == 'true' %}
+  <footer>
+      <div class="article-date">
+        {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %}</div>
+  </footer>
+  {% endif %}
+{% else %}
+  <section>{{ content }}</section>
+{% endif %}
+


### PR DESCRIPTION
If the page is an index page and there is an excerpt in the post then
don't display the full article. Only until the excerpt.

Reference: http://octopress.org/docs/blogging/
